### PR TITLE
Surround Invalid Expressions with single quotes instead of replacing them with an ellipses

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pybind11-stubgen [-h]
                   --numpy-array-use-type-var|
                   --numpy-array-remove-parameters]
                  [--print-invalid-expressions-as-is]
+                 [--surround-invalid-expressions-with-single-quotes]
                  [--print-value-comments]
                  [--print-safe-value-reprs REGEX]
                  [--exit-code]
@@ -44,15 +45,20 @@ Contributing
 ------------
 
 During development, you may need to update the reference stubs in tests/stubs. This can be done locally using a convenience tox configuration. Ensure that all Python interpreters required by the test suite are available in your environment. For example, you can install them via uv:
+
 ```shell
 uv python install 3.10 3.11 3.12 3.13
 ```
+
 To enable the repository hooks locally:
+
 ```shell
 uv sync
 uv run pre-commit install
 ```
+
 To regenerate the reference stubs run:
+
 ```shell
 uv venv
 source .venv/bin/activate

--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -75,6 +75,7 @@ class CLIArgs(Namespace):
     numpy_array_use_type_var: bool
     numpy_array_remove_parameters: bool
     print_invalid_expressions_as_is: bool
+    surround_invalid_expressions_with_single_quotes: bool
     print_safe_value_reprs: re.Pattern | None
     print_value_comments: bool
     exit_code: bool
@@ -185,6 +186,14 @@ def arg_parser() -> ArgumentParser:
         action="store_true",
         help="Suppress the replacement with '...' of invalid expressions"
         "found in annotations",
+    )
+
+    parser.add_argument(
+        "--surround-invalid-expressions-with-single-quotes",
+        default=False,
+        action="store_true",
+        help="Surround invalid expressions found in annotations with single quotes (')"
+        "to postprocess them more easily e.g. with ast.parse(); Overwrites --print-invalid-expressions-as-is",
     )
 
     parser.add_argument(
@@ -325,6 +334,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     printer = Printer(
         invalid_expr_as_ellipses=not args.print_invalid_expressions_as_is,
         print_value_comments=args.print_value_comments,
+        surround_invalid_expr_with_single_quotes=args.surround_invalid_expressions_with_single_quotes,
     )
 
     run(

--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -184,7 +184,7 @@ def arg_parser() -> ArgumentParser:
         "--print-invalid-expressions-as-is",
         default=False,
         action="store_true",
-        help="Suppress the replacement with '...' of invalid expressions"
+        help="Suppress the replacement with '...' of invalid expressions "
         "found in annotations",
     )
 
@@ -192,7 +192,7 @@ def arg_parser() -> ArgumentParser:
         "--surround-invalid-expressions-with-single-quotes",
         default=False,
         action="store_true",
-        help="Surround invalid expressions found in annotations with single quotes (')"
+        help="Surround invalid expressions found in annotations with single quotes (') "
         "to postprocess them more easily e.g. with ast.parse(); Overwrites --print-invalid-expressions-as-is",
     )
 

--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -183,8 +183,7 @@ def arg_parser() -> ArgumentParser:
         "--print-invalid-expressions-as-is",
         default=False,
         action="store_true",
-        help="Suppress the replacement with '...' of invalid expressions"
-        "found in annotations",
+        help="Remove the quotation marks around invalid expressions found in annotations",
     )
 
     parser.add_argument(
@@ -323,7 +322,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     parser = stub_parser_from_args(args)
     printer = Printer(
-        invalid_expr_as_ellipses=not args.print_invalid_expressions_as_is,
+        invalid_expr_in_quotation_marks=not args.print_invalid_expressions_as_is,
         print_value_comments=args.print_value_comments,
     )
 

--- a/pybind11_stubgen/printer.py
+++ b/pybind11_stubgen/printer.py
@@ -141,8 +141,12 @@ class Printer:
         self,
         invalid_expr_as_ellipses: bool,
         print_value_comments: bool = False,
+        surround_invalid_expr_with_single_quotes: bool = False,
     ):
         self.invalid_expr_as_ellipses = invalid_expr_as_ellipses
+        self.surround_invalid_expr_with_single_quotes = (
+            surround_invalid_expr_with_single_quotes
+        )
         self.print_value_comments = print_value_comments
 
     def _order_classes(self, classes: list[Class]) -> list[Class]:
@@ -440,6 +444,8 @@ class Printer:
             raise AssertionError()
 
     def print_invalid_exp(self, invalid_expr: InvalidExpression) -> str:
+        if self.surround_invalid_expr_with_single_quotes:
+            return f"'{invalid_expr.text}'"
         if self.invalid_expr_as_ellipses:
             return "..."
         return invalid_expr.text

--- a/pybind11_stubgen/printer.py
+++ b/pybind11_stubgen/printer.py
@@ -139,10 +139,10 @@ def _topological_sort_classes(classes: list[Class]) -> list[Class]:
 class Printer:
     def __init__(
         self,
-        invalid_expr_as_ellipses: bool,
+        invalid_expr_in_quotation_marks: bool,
         print_value_comments: bool = False,
     ):
-        self.invalid_expr_as_ellipses = invalid_expr_as_ellipses
+        self.invalid_expr_in_quotation_marks = invalid_expr_in_quotation_marks
         self.print_value_comments = print_value_comments
 
     def _order_classes(self, classes: list[Class]) -> list[Class]:
@@ -440,6 +440,6 @@ class Printer:
             raise AssertionError()
 
     def print_invalid_exp(self, invalid_expr: InvalidExpression) -> str:
-        if self.invalid_expr_as_ellipses:
-            return "..."
+        if self.invalid_expr_in_quotation_marks:
+            return f"'{invalid_expr.text}'"
         return invalid_expr.text


### PR DESCRIPTION
Hellau,

Thanks for this nice repository to create stubs!

I had an issue: Using '--print-invalid-expressions-as-is' I could not use ast.parse() to postprocess these invalid expression. If Not setting this flag replaces them with ellipses - so also not good.

My suggestion is, to surround the invalid expressions found in type annotations with single quotes.
This way they are represented as ast.Constant() by ast.parse().

I did test it on my own project creating stub files for [casadi](https://github.com/casadi/casadi) and it worked flawlessly.

I did not write any tests since I wanted your feedback first. E.g. if Printer.invalid_expr_as_ellipses should be removed, since there is a better option or if surrounding by quotes should even become the default from now on.

Greetings
Leander